### PR TITLE
Add 'ExceptionNotifier.html' and use symfony/var-dumper

### DIFF
--- a/Lib/Error/ExceptionNotifierErrorHandler.php
+++ b/Lib/Error/ExceptionNotifierErrorHandler.php
@@ -23,7 +23,7 @@ class ExceptionNotifierErrorHandler extends ErrorHandler {
         list($error, $log) = self::mapErrorCode($code);
         $prefix = Configure::read('ExceptionNotifier.prefix');
         $subject = $prefix . '['. date('Ymd H:i:s') . '][' . strtoupper($error) . '][' . ExceptionText::getUrl() . '] ' . $description;
-        $body = ExceptionText::getText($error . ':' . $description, $file, $line, $context);
+        $body = ExceptionText::getBody($error . ':' . $description, $file, $line, $context);
         return ExceptionMail::send($subject, $body);
     }
 
@@ -58,7 +58,7 @@ class ExceptionNotifierErrorHandler extends ErrorHandler {
         if (($force || $debug == 0) && self::_checkAllowed($exception)) {
             $prefix = Configure::read('ExceptionNotifier.prefix');
             $subject = $prefix . '['. date('Ymd H:i:s') . '][Exception][' . ExceptionText::getUrl() . '] ' . $exception->getMessage();
-            $body = ExceptionText::getText($exception->getMessage(), $exception->getFile(), $exception->getLine());
+            $body = ExceptionText::getBody($exception->getMessage(), $exception->getFile(), $exception->getLine());
             ExceptionMail::send($subject, $body);
         }
 

--- a/Lib/ExceptionText.php
+++ b/Lib/ExceptionText.php
@@ -1,5 +1,19 @@
 <?php
+use Symfony\Component\VarDumper\Cloner\VarCloner;
+use Symfony\Component\VarDumper\Dumper\CliDumper;
+use Symfony\Component\VarDumper\Dumper\HtmlDumper;
+
 class ExceptionText {
+
+    private static $handler;
+
+    public static function getBody($message, $file, $line, $context = null){
+        $html = Configure::read('ExceptionNotifier.html');
+        if ($html) {
+            return self::getHtml($message, $file, $line, $context);
+        }
+        return self::getText($message, $file, $line, $context);
+    }
 
     public static function getText($message, $file, $line, $context = null){
         $params = Router::getRequest();
@@ -9,6 +23,12 @@ class ExceptionText {
         $msg = array(
             $message,
             $file . '(' . $line . ')',
+            '',
+            '-------------------------------',
+            'Backtrace:',
+            '-------------------------------',
+            '',
+            trim($trace),
             '',
             '-------------------------------',
             'Request:',
@@ -38,12 +58,6 @@ class ExceptionText {
             trim(print_r($_COOKIE, true)),
             '',
             '-------------------------------',
-            'Backtrace:',
-            '-------------------------------',
-            '',
-            trim($trace),
-            '',
-            '-------------------------------',
             'Context:',
             '-------------------------------',
             '',
@@ -52,6 +66,82 @@ class ExceptionText {
             );
 
         return join("\n", $msg);
+    }
+
+    public static function getHtml($message, $file, $line, $context = null){
+        $params = Router::getRequest();
+        $trace = Debugger::trace(array('start' => 2, 'format' => 'base'));
+        $session = isset($_SESSION) ? $_SESSION : array();
+
+        $msg = array(
+            '<p><strong>',
+            $message,
+            '</strong></p>',
+            '<p>',
+            $file . '(' . $line . ')',
+            '</p>',
+            '',
+            '<h2>',
+            'Backtrace:',
+            '</h2>',
+            '',
+            '<pre>',
+            trim($trace),
+            '</pre>',
+            '',
+            '<h2>',
+            'Request:',
+            '</h2>',
+            '',
+            '<h3>URL</h3>',
+            self::getUrl(),
+            '<h3>IP address</h3>',
+            env('REMOTE_ADDR'),
+            '<h3>Parameters</h3>',
+            self::dumper($params),
+            '<h3>Cake root</h3>',
+            APP,
+            '',
+            '<h2>',
+            'Environment:',
+            '</h2>',
+            '',
+            self::dumper($_SERVER),
+            '',
+            '<h2>',
+            'Session:',
+            '</h2>',
+            '',
+            self::dumper($session),
+            '',
+            '<h2>',
+            'Cookie:',
+            '</h2>',
+            '',
+            self::dumper($_COOKIE),
+            '',
+            '<h2>',
+            'Context:',
+            '</h2>',
+            '',
+            self::dumper($context),
+            '',
+            );
+
+        return join("\n", $msg);
+    }
+
+    public static function dumper($obj) {
+        ob_start();
+        $cloner = new VarCloner();
+        $dumper = new HtmlDumper();
+        self::$handler = function ($obj) use ($cloner, $dumper) {
+            $dumper->dump($cloner->cloneVar($obj));
+        };
+        call_user_func(self::$handler, $obj);
+        $ret = ob_get_contents();
+        ob_end_clean();
+        return $ret;
     }
 
     public static function getUrl() {

--- a/Lib/Network/Email/ExceptionMail.php
+++ b/Lib/Network/Email/ExceptionMail.php
@@ -12,6 +12,10 @@ class ExceptionMail {
     public static function send($subject, $body){
         try{
             $email = new CakeEmail('error');
+            $html = Configure::read('ExceptionNotifier.html');
+            if ($html) {
+                $email->emailFormat('html');
+            }
             $from = $email->from();
             if (empty($from)) {
                 $email->from('exception.notifier@default.com', 'Exception Notifier');

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
         }
     ],
     "require": {
-        "composer/installers": "*"
+        "composer/installers": "*",
+        "symfony/var-dumper": "*"
     }
 }


### PR DESCRIPTION
- `print_r` not support huge object (ex. recursion object)
- `symfony/var-dumper` support recursive depth setting

So add 'ExceptionNotifier.html' option (send HTML mail with var-dumper) 