### PR TITLE
remove typehinting

### DIFF
--- a/Lib/Error/ExceptionNotifierErrorHandler.php
+++ b/Lib/Error/ExceptionNotifierErrorHandler.php
@@ -33,7 +33,7 @@ class ExceptionNotifierErrorHandler extends ErrorHandler {
      *
      * @param Exception $exception
      */
-    public static function handleException(Exception $exception){
+    public static function handleException($exception){
 
         /**
          * @see ErrorHandler::handleException


### PR DESCRIPTION
Cake本体からExceptionのtypehinting削除されているので削除したほうがいいかと思います。 
https://github.com/cakephp/cakephp/commit/7982b6b078da74474f50aea776d4f623c7763e16