### PR TITLE
2.8 PHP7 compatibility

### DIFF
--- a/Lib/Error/ExceptionNotifierErrorHandler.php
+++ b/Lib/Error/ExceptionNotifierErrorHandler.php
@@ -39,7 +39,7 @@ class ExceptionNotifierErrorHandler extends ErrorHandler
      *
      * @param Exception $exception
      */
-    public static function handleException(Exception $exception)
+    public static function handleException($exception)
     {
 
         /**

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
   ],
   "require": {
     "php": ">=5.3.3",
-    "cakephp/cakephp": "~2.0,<2.8",
+    "cakephp/cakephp": ">=2.8",
     "composer/installers": "*",
     "symfony/var-dumper": "*"
   }

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
   ],
   "require": {
     "php": ">=5.3.3",
-    "cakephp/cakephp": ">=2.8",
+    "cakephp/cakephp": "~2.0,>=2.8",
     "composer/installers": "*",
     "symfony/var-dumper": "*"
   }


### PR DESCRIPTION
In CakePHP 2.8 the following changes have been made for PHP 7 compatibility.
https://github.com/cakephp/cakephp/pull/7840

Due to the above change, the following error occurred in ExceptionNotifierErrorHandler.

```
Strict Standards: Declaration of ExceptionNotifierErrorHandler::handleException() should be compatible with ErrorHandler::handleException($exception) in /Plugin/Exception/Lib/Error/ExceptionNotifierErrorHandler.php on line 0
```
Can you delete type hints for CakePHP 2.8 compatibility?